### PR TITLE
[MY] Optimize IA-16 build with -O2

### DIFF
--- a/my_frontend/Makefile.ia16
+++ b/my_frontend/Makefile.ia16
@@ -19,7 +19,8 @@ CFLAGS = \
     -DSUPPORTS_HACKING_MINIGAME \
     -DENDIANESS_AWARE \
     -DMONOCHROME_VECTORS \
-    -DUSE_OWN_MIN_MAX
+    -DUSE_OWN_MIN_MAX \
+    -O2
 
 CC = ia16-elf-gcc
 STRIP = ia16-elf-strip

--- a/my_frontend/src/msdos.c
+++ b/my_frontend/src/msdos.c
@@ -452,6 +452,8 @@ enum ECommand getInput(void) {
     return kCommandNone;
 }
 
+// internal compiler error: Max. number of generated reload insns per insn is achieved (90)
+__attribute__((optimize("-O0")))
 void drawTextAtWithMarginWithFiltering(const int _x, const int _y, int limitX, const char *text, const uint8_t fg,
                                        char charToReplaceHifenWith) {
 


### PR DESCRIPTION
Reduces the binary size by ~10 KiB, and probably makes it a ltitle faster, too.